### PR TITLE
fixed an undef error where server was calling functions in plugin module

### DIFF
--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -14,7 +14,7 @@
 %% Copyright (c) 2007-2011 VMware, Inc.  All rights reserved.
 %%
 
--module(rabbit_auth_backend_http).
+-module(rabbitmq_auth_backend_http).
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 


### PR DESCRIPTION
server was calling the functions in rabbitmq-auth-backend-http but the module name was called rabbit-auth-backend-http. Changed the module name to be consistent with the plugin name.