### PR TITLE
Add IP address parameter to vhost path

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ as follows:
 
 * `username`   - the name of the user
 * `vhost`      - the name of the virtual host being accessed
+* `ip`         - the client ip address
 
 Note that you cannot create arbitrary virtual hosts using this plugin; you can only determine whether your users can see / access the ones that exist.
 

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -57,7 +57,7 @@ user_login_authorization(Username) ->
 check_vhost_access(#auth_user{username = Username}, VHost, Sock) ->
     bool_req(vhost_path, [{username, Username},
                           {vhost,    VHost},
-			  {ip, inet_parse:ntoa(extract_address(Sock))}]).
+			  {ip,       extract_address(Sock)}]).
 
 check_resource_access(#auth_user{username = Username},
                       #resource{virtual_host = VHost, kind = Type, name = Name},
@@ -122,9 +122,9 @@ parse_resp(Resp) -> string:to_lower(string:strip(Resp)).
 extract_address(undefined) -> undefined;
 % for native direct connections the address is set to unknown
 extract_address(#authz_socket_info{peername={unknown, _Port}}) -> undefined;
-extract_address(#authz_socket_info{peername={Address, _Port}}) -> Address;
+extract_address(#authz_socket_info{peername={Address, _Port}}) -> inet_parse:ntoa(Address);
 extract_address(Sock) ->
     {ok, {Address, _Port}} = rabbit_net:peername(Sock),
-    Address.
+    inet_parse:ntoa(Address).
 
 %%--------------------------------------------------------------------

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -54,9 +54,10 @@ user_login_authorization(Username) ->
         Else                          -> Else
     end.
 
-check_vhost_access(#auth_user{username = Username}, VHost, _Sock) ->
+check_vhost_access(#auth_user{username = Username}, VHost, Sock) ->
     bool_req(vhost_path, [{username, Username},
-                          {vhost,    VHost}]).
+                          {vhost,    VHost},
+			  {ip, inet_parse:ntoa(extract_address(Sock))}]).
 
 check_resource_access(#auth_user{username = Username},
                       #resource{virtual_host = VHost, kind = Type, name = Name},
@@ -115,5 +116,15 @@ escape(K, V) ->
     atom_to_list(K) ++ "=" ++ mochiweb_util:quote_plus(V).
 
 parse_resp(Resp) -> string:to_lower(string:strip(Resp)).
+
+%%--------------------------------------------------------------------
+
+extract_address(undefined) -> undefined;
+% for native direct connections the address is set to unknown
+extract_address(#authz_socket_info{peername={unknown, _Port}}) -> undefined;
+extract_address(#authz_socket_info{peername={Address, _Port}}) -> Address;
+extract_address(Sock) ->
+    {ok, {Address, _Port}} = rabbit_net:peername(Sock),
+    Address.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Give the ability to HTTP server to verify the client IP address via passing the IP to vhost path.
It will be useful for who has authorization backend vi IP address.