### PR TITLE
Remove the dependency on mochiweb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_auth_backend_http
 
-DEPS = rabbit_common rabbit amqp_client mochiweb
+DEPS = rabbit_common rabbit amqp_client
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/src/rabbitmq_auth_backend_http.app.src
+++ b/src/rabbitmq_auth_backend_http.app.src
@@ -10,4 +10,4 @@
          {vhost_path,    "http://localhost:8000/auth/vhost"},
          {resource_path, "http://localhost:8000/auth/resource"}] },
   {broker_version_requirements, ["3.6.0", "3.7.0"]},
-  {applications, [kernel, stdlib, inets, rabbit_common, rabbit, amqp_client, mochiweb]}]}.
+  {applications, [kernel, stdlib, inets, rabbit_common, rabbit, amqp_client]}]}.


### PR DESCRIPTION
It was only using mochiweb_util, which was moved to rabbit_common.

Part of rabbitmq/rabbitmq-common#46