### PR TITLE
Handle map in HTTP parameters

### DIFF
--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -154,7 +154,7 @@ q(Args) ->
     string:join([escape(K, V) || {K, V} <- Args], "&").
 
 escape(K, Map) when is_map(Map) ->
-    string:join([escape(atom_to_list(K) ++ "." ++ rabbit_data_coercion:to_list(Key), Value)
+    string:join([escape(rabbit_data_coercion:to_list(K) ++ "." ++ rabbit_data_coercion:to_list(Key), Value)
         || {Key, Value} <- maps:to_list(Map)], "&");
 escape(K, V) ->
     rabbit_data_coercion:to_list(K) ++ "=" ++ rabbit_http_util:quote_plus(V).

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -153,8 +153,11 @@ p(PathName) ->
 q(Args) ->
     string:join([escape(K, V) || {K, V} <- Args], "&").
 
+escape(K, Map) when is_map(Map) ->
+    string:join([escape(atom_to_list(K) ++ "." ++ rabbit_data_coercion:to_list(Key), Value)
+        || {Key, Value} <- maps:to_list(Map)], "&");
 escape(K, V) ->
-    atom_to_list(K) ++ "=" ++ rabbit_http_util:quote_plus(V).
+    rabbit_data_coercion:to_list(K) ++ "=" ++ rabbit_http_util:quote_plus(V).
 
 parse_resp(Resp) -> string:to_lower(string:strip(Resp)).
 

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -1,0 +1,54 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+%%
+
+-module(unit_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-compile(export_all).
+
+all() ->
+    [
+        {group, non_parallel_tests}
+    ].
+
+groups() ->
+    [
+        {non_parallel_tests, [], [
+            query
+        ]}
+    ].
+
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+
+query(_Config) ->
+    "username=guest&vhost=%2F&resource=topic&name=amp.topic&permission=write" =
+            rabbit_auth_backend_http:q([
+                {username,   <<"guest">>},
+                {vhost,      <<"/">>},
+                {resource,   topic},
+                {name,       <<"amp.topic">>},
+                {permission, write}]),
+
+    "username=guest&routing_key=a.b.c&variable_map.username=guest&variable_map.vhost=other-vhost" =
+        rabbit_auth_backend_http:q([
+            {username,   <<"guest">>},
+            {routing_key,<<"a.b.c">>},
+            {variable_map, #{<<"username">> => <<"guest">>,
+                             <<"vhost">>    => <<"other-vhost">>}
+            }]),
+    ok.


### PR DESCRIPTION
An Erlang map is turned into several HTTP parameters. E.g.
{variable_map, #{username => guest, vhost = some-vhost}} is
converted into 2 HTTP parameters: variable_map.username=guest
and variable_map.vhost=some-vhost.

Fixes #53