### PR TITLE
Add vhost as request params to user_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ against the URIs listed in the configuration file. It will add query string
 
 * `username` - the name of the user
 * `password` - the password provided (may be missing if e.g. rabbitmq-auth-mechanism-ssl is used)
+* `vhost`    - the name of the virtual host being accessed
 
 ### vhost_path
 

--- a/examples/rabbitmq_auth_backend_spring_boot/src/main/java/com/rabbitmq/examples/AuthBackendHttpController.java
+++ b/examples/rabbitmq_auth_backend_spring_boot/src/main/java/com/rabbitmq/examples/AuthBackendHttpController.java
@@ -46,7 +46,8 @@ public class AuthBackendHttpController {
 
     @RequestMapping("user")
     public String user(@RequestParam("username") String username,
-                       @RequestParam("password") String password) {
+                       @RequestParam("password") String password,
+                       @RequestParam("vhost") String vhost) {
         LOGGER.info("Trying to authenticate user {}", username);
         User user = users.get(username);
         if (user != null && user.getPassword().equals(password)) {


### PR DESCRIPTION
I'm working on rabbit 3.6.10, Erlang R16B03, with `rabbitmq_auth_backend_http` version `3.6.12+2.g430e0e3` (as from `rabbitmq-plugins list`). Noticed a small discrepancy in the README, so just a quick text update. 