### PR TITLE
Added example for dotnet webapi that rabbitmq-auth-backend-http can authenticate against

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Check the RabbitMQ logs if things don't seem to be working
 properly. Look for log messages containing "rabbit_auth_backend_http
 failed".
 
-## Example Apps (Python and Spring Boot)
+## Example Apps (Python, Spring Boot and DotNet-WebApi)
 
 In `examples/rabbitmq_auth_backend_django` there's a very simple
 Django app that can be used for authentication. On Debian / Ubuntu you
@@ -158,6 +158,10 @@ In `examples/rabbitmq_auth_backend_spring_boot` there's a Spring Boot app
 that can be used for authentication. You'll need Java 1.8 and Maven
 to run it. It's really not designed to be anything other
 than an example.
+
+In `examples/rabbitmq_auth_backend_webapi_dotnet` is a very minimalistic DotNet WebApi application
+that rabbitmq-auth-backend-http can authenticate against.You'll need DotNet4.5 and Visual Studio
+to run it It's really not designed to be anything other than an example.
 
 See `examples/README` for slightly more information.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,3 +41,55 @@ Have a look at the `AuthBackendHttpController`. There's only one user: `guest`,
 with the `guest` password. This implementation also checks the
 routing key starts with an `a` when publishing to a topic exchange 
 or consuming from a topic. (an example of [topic authorisation](http://next.rabbitmq.com/access-control.html#topic-authorisation)).
+
+## DotNet WebApi Example
+
+`rabbitmq_auth_backend_webapi_dotnet` is a very minimalistic DotNet WebApi application
+that rabbitmq-auth-backend-http can authenticate against. It's really
+not designed to be anything other than an example.
+
+### Running the Example
+
+Open the WebApiHttpAuthService.csproj in Visual Studio 2017, More details are giving in below section "Where was this sample tested"
+Build the solution and run it from Visual Studio, Then make changes to rabbitmq.config file for the URL or HTTPEndpoints refer to section below "rabbitmq.config file changes"
+You can write custom logic inside Controllers/AuthController.cs, By default All users get access to all vhosts and
+resources. An example of deny is also given for one user "authuser".
+
+### HTTP Endpoint Examples
+
+Have a look at the `AuthController`.
+
+### Where was this sample tested
+DotNetFramework 4.5
+Visual Studio 2017
+Windows10, This application is Hosted on IIS V10.0
+if not using IIS, build and run service from Visual Studio browse the endpoint
+something like
+http://localhost:62190 port number-62190 might vary, 
+If hosted on IIS and using the default port 80, then port number might not be required 
+
+### rabbitmq.config file changes
+Copy url from the browsed website and put it in rabbitmq.config file
+like below
+
+[
+
+{rabbit, [
+            {auth_backends, [rabbit_auth_backend_internal,rabbit_auth_backend_http]}
+          ]
+},
+
+{
+rabbitmq_auth_backend_http,
+   [
+		{http_method,   post},
+		{user_path,     "http://localhost:62190/auth/user"},
+		{vhost_path,    "http://localhost:62190/auth/vhost"},
+		{resource_path, "http://localhost:62190/auth/resource"},
+		{topic_path,    "http://localhost:62190/auth/topic"}
+	]
+}
+
+].
+
+Now it should start authenticating/authorizing from the new http service if not found in rabbit_auth_backend_internal configuration

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/App_Start/WebApiConfig.cs
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/App_Start/WebApiConfig.cs
@@ -1,0 +1,12 @@
+﻿using System.Web.Http;
+
+namespace WebApiHttpAuthService
+{
+    public static class WebApiConfig
+    {
+        public static void Register(HttpConfiguration config)
+        {
+            config.MapHttpAttributeRoutes();
+        }
+    }
+}

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Controllers/AuthController.cs
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Controllers/AuthController.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Web.Http;
+
+namespace WebApiHttpAuthService.Controllers
+{
+    [RoutePrefix("auth")]
+    public class AuthController : ApiController
+    {
+
+       [Route("user")]
+        [HttpPost]
+        public HttpResponseMessage user(FormDataCollection form)
+        {
+            string content = "allow [administrator, management]";
+            try
+            {
+                if (form != null)
+                {
+                    string username = form.Get("username");
+                    string password = form.Get("password");
+
+                    if(username=="authuser") //Sample check you can put your custom logic over here
+                        content = "deny";
+
+                    string userlog = string.Format("user :{0}, password :{1}", username, password);
+                }
+            }
+            catch(Exception ex)
+            {
+                //check or log error
+            }
+
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Content = new StringContent(content, System.Text.Encoding.UTF8, "text/plain");
+            return resp;
+        }
+
+        [Route("vhost")]
+        [HttpPost]
+        public HttpResponseMessage vhost(FormDataCollection form)
+        {
+            string content = "allow";
+            try
+            {
+                if (form != null)
+                {
+                    string username = form.Get("username");
+                    string ip = form.Get("ip");
+
+                    if (username == "authuser") //Sample checks you can put your custom logic over here
+                        content = "deny";
+
+                    string userlog = string.Format("user :{0}, ip :{1}", username, ip);
+                }
+            }
+            catch (Exception ex)
+            {
+                //check or log error
+            }
+
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Content = new StringContent(content, System.Text.Encoding.UTF8, "text/plain");
+            return resp;
+        }
+
+        [Route("resource")]
+        [HttpPost]
+        public HttpResponseMessage resource(FormDataCollection form)
+        {
+            string content = "allow";
+
+            try
+            {
+                if (form != null)
+                {
+                    string username = form.Get("username");
+                    string vhost = form.Get("vhost");
+                    string resource = form.Get("resource");
+                    string name = form.Get("name");
+                    string permission = form.Get("permission");
+
+                    if (username == "authuser") //Sample checks you can put your custom logic over here
+                        content = "deny";
+
+                    string userlog = string.Format("user :{0}, vhost :{1}, resource :{2}, name: {3}, permission: {4}", username, vhost, resource, name, permission);
+                   
+                }
+            }
+            catch (Exception ex)
+            {
+                //check or log error
+            }
+
+
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Content = new StringContent(content, System.Text.Encoding.UTF8, "text/plain");
+            return resp;
+        }
+
+        [Route("topic")]
+        [HttpPost]
+        public HttpResponseMessage topic(FormDataCollection form)
+        {
+            string content = "allow";
+            try
+            {
+                if (form != null)
+                {
+                    string username = form.Get("username");
+                    string vhost = form.Get("vhost");
+                    string resource = form.Get("resource");
+                    string name = form.Get("name");
+                    string permission = form.Get("permission");
+                    string routing_key = form.Get("routing_key");
+
+                    if (username == "authuser") //Sample checks you can put your custom logic over here
+                        content = "deny";
+
+                    string userlog = string.Format("user :{0}, vhost :{1}, resource :{2}, name: {3}, permission: {4}, routing_key :{5}", username, vhost, resource, name, permission, routing_key);
+
+                }
+            }
+            catch (Exception ex)
+            {
+                //check or log error
+            }
+
+            var resp = new HttpResponseMessage(HttpStatusCode.OK);
+            resp.Content = new StringContent(content, System.Text.Encoding.UTF8, "text/plain");
+            return resp;
+        }
+                       
+
+
+    }
+}

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Global.asax
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Global.asax
@@ -1,0 +1,1 @@
+﻿<%@ Application Codebehind="Global.asax.cs" Inherits="WebApiHttpAuthService.WebApiApplication" Language="C#" %>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Global.asax.cs
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Global.asax.cs
@@ -1,0 +1,12 @@
+﻿using System.Web.Http;
+
+namespace WebApiHttpAuthService
+{
+    public class WebApiApplication : System.Web.HttpApplication
+    {
+        protected void Application_Start()
+        {
+            GlobalConfiguration.Configure(WebApiConfig.Register);
+        }
+    }
+}

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Properties/AssemblyInfo.cs
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebApiHttpAuthService")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WebApiHttpAuthService")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f141c3e3-fd04-475b-b2b9-00328d0f907b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Web.Debug.config
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Web.Release.config
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/Web.config
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/Web.config
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=301879
+  -->
+<configuration>
+  <appSettings />
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.5" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
+  </system.web>
+  
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+
+    </assemblyBinding>
+  </runtime>
+<system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer></configuration>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj
@@ -1,0 +1,140 @@
+﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{F141C3E3-FD04-475B-B2B9-00328D0F907B}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebApiHttpAuthService</RootNamespace>
+    <AssemblyName>WebApiHttpAuthService</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Practices.ServiceLocation">
+      <HintPath>..\..\VEMS.Sample\Dependencies\WSF\Microsoft.Practices.ServiceLocation.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Global.asax" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\AuthController.cs" />
+    <Compile Include="Global.asax.cs">
+      <DependentUpon>Global.asax</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="App_Data\" />
+    <Folder Include="Models\" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>62243</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:62190/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -48,14 +48,10 @@
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\..\VEMS.Sample\Dependencies\WSF\Microsoft.Practices.ServiceLocation.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -66,11 +62,11 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http">
+      <HintPath>packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    <Reference Include="System.Web.Http.WebHost">
+      <HintPath>packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj.user
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.csproj.user
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <WebStackScaffolding_ControllerDialogWidth>600</WebStackScaffolding_ControllerDialogWidth>
+    <WebStackScaffolding_IsLayoutPageSelected>True</WebStackScaffolding_IsLayoutPageSelected>
+    <WebStackScaffolding_IsPartialViewSelected>False</WebStackScaffolding_IsPartialViewSelected>
+    <WebStackScaffolding_IsReferencingScriptLibrariesSelected>True</WebStackScaffolding_IsReferencingScriptLibrariesSelected>
+    <WebStackScaffolding_LayoutPageFile />
+    <WebStackScaffolding_IsAsyncSelected>False</WebStackScaffolding_IsAsyncSelected>
+  </PropertyGroup>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <StartPageUrl>
+          </StartPageUrl>
+          <StartAction>CurrentPage</StartAction>
+          <AspNetDebugging>True</AspNetDebugging>
+          <SilverlightDebugging>False</SilverlightDebugging>
+          <NativeDebugging>False</NativeDebugging>
+          <SQLDebugging>False</SQLDebugging>
+          <ExternalProgram>
+          </ExternalProgram>
+          <StartExternalURL>
+          </StartExternalURL>
+          <StartCmdLineArguments>
+          </StartCmdLineArguments>
+          <StartWorkingDirectory>
+          </StartWorkingDirectory>
+          <EnableENC>True</EnableENC>
+          <AlwaysStartWebServerOnDebug>True</AlwaysStartWebServerOnDebug>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.sln
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/WebApiHttpAuthService.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.8
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiHttpAuthService", "WebApiHttpAuthService.csproj", "{F141C3E3-FD04-475B-B2B9-00328D0F907B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F141C3E3-FD04-475B-B2B9-00328D0F907B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F141C3E3-FD04-475B-B2B9-00328D0F907B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F141C3E3-FD04-475B-B2B9-00328D0F907B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F141C3E3-FD04-475B-B2B9-00328D0F907B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2E60A79D-A68A-4486-A8F2-917C08BA2C8A}
+	EndGlobalSection
+EndGlobal

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/newfile
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/newfile
@@ -1,0 +1,1 @@
+this is new file

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/newfile
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/newfile
@@ -1,1 +1,0 @@
-this is new file

--- a/examples/rabbitmq_auth_backend_webapi_dotnet/packages.config
+++ b/examples/rabbitmq_auth_backend_webapi_dotnet/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Added example for dotnet webapi that rabbitmq-auth-backend-http can authenticate against. `rabbitmq_auth_backend_webapi_dotnet` is a very minimalistic DotNet WebApi application
that rabbitmq-auth-backend-http can authenticate against. It's really
not designed to be anything other than an example.