### PR TITLE
Add auth backend PHP example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -77,10 +77,66 @@ Port number may vary but will likely be `62190`.
 
 When the example is hosted on IIS, port 80 will be used by default.
 
+## PHP Boot Example
+
+`rabbitmq_auth_backend_php` is a simple [PHP](http://php.net/) application that rabbitmq-auth-backend-http can authenticate against.
+It's really not designed to be anything other than an example.
+
+### Running the Example
+
+First of all, you need PHP >= 5.4 and [Composer](https://getcomposer.org/) (php package manager).
+
+> ℹ️ The library need PHP >= 5.3, but to run this example you need the PHP >= 5.4 (only because PHP 5.4 as an internal webserver)
+
+The `rabbitmq-auth-backend-http-php` library depend on `symfony/security` and `symfony/http-foundation` components.
+Go to the `rabbitmq_auth_backend_php` folder and run `composer install`.
+
+```bash
+$ cd rabbitmq_auth_backend_php/
+$ composer install
+```
+
+Now you can run the PHP 5.4 server (server at http://127.0.0.1:8080)
+
+```
+$ composer start
+```
+
+Ensure the log file is writable `rabbitmq-auth-backend-http/examples/rabbitmq_auth_backend_php/var/log.log`.
+
+Go to `http://localhost:8080/user.php?username=Anthony&password=anthony-password`, all work properly if you see `Allow administrator` 
+
+### HTTP Endpoint Examples
+
+Have a look at the `bootstrap.php`. By default this example implement the same authorization rules than RabbitMQ.
+
+Users list:
+
+| User | password | is admin | Vhost | Configure regex | Write regex | Read regex | tags |
+|--|--|--|--|--|--|--|--|
+| Anthony | anthony-password | ✔️ | All | All | All | All | administrator |
+| James | bond | | / | .* | .* | .* | management |
+| Roger | rabbit | | | | | | monitoring |
+| bunny | bugs | | | | | | policymaker |
+
 ### rabbitmq.config Example
+
+ℹ️ Dont forget to set the proper url in your rabbit config file
 
 Below is a [RabbitMQ config file](http://www.rabbitmq.com/configure.html) example to go with this
 example:
+
+the new format
+```
+auth_backends.1 = internal  
+auth_backends.2 = http
+auth_http.user_path     = http://localhost:62190/auth/user.php  
+auth_http.vhost_path    = http://localhost:62190/auth/vhost.php  
+auth_http.resource_path = http://localhost:62190/auth/resource.php  
+auth_http.topic_path    = http://localhost:62190/auth/topic.php
+```
+
+Or 
 
 ``` erlang
 [

--- a/examples/rabbitmq_auth_backend_php/.gitignore
+++ b/examples/rabbitmq_auth_backend_php/.gitignore
@@ -1,0 +1,3 @@
+vendor
+var
+composer.lock

--- a/examples/rabbitmq_auth_backend_php/composer.json
+++ b/examples/rabbitmq_auth_backend_php/composer.json
@@ -1,0 +1,19 @@
+{
+    "description": "Example RabbitMQ http auth backend php",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Anthony",
+            "email": "instabledesign@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.4",
+        "symftony/rabbitmq-auth-backend-http-php": "dev-master",
+        "monolog/monolog": "^1.23"
+    },
+    "scripts": {
+        "start": "php -S 127.0.0.1:8080 -t src"
+    }
+}

--- a/examples/rabbitmq_auth_backend_php/src/bootstrap.php
+++ b/examples/rabbitmq_auth_backend_php/src/bootstrap.php
@@ -1,0 +1,136 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
+use RabbitMQAuth\Authentication\Authenticator;
+use RabbitMQAuth\Authentication\ChainAuthenticationChecker;
+use RabbitMQAuth\Authentication\UserPasswordTokenChecker;
+use RabbitMQAuth\Authentication\UserTokenChecker;
+use RabbitMQAuth\Authorization\DefaultVoter;
+use RabbitMQAuth\Controller\AuthController;
+use RabbitMQAuth\Security;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+/**
+ * You must can edit the following users and theyre roles (tags)
+ */
+$userProvider = new InMemoryUserProvider(array(
+    //Admin user
+    'Anthony' => array(
+        'password' => 'anthony-password',
+        'roles' => array(
+            'administrator',
+            // 'impersonator', // report to https://www.rabbitmq.com/validated-user-id.html
+        ),
+    ),
+    'James' => array(
+        'password' => 'bond',
+        'roles' => array(
+            'management',
+        ),
+    ),
+    'Roger' => array(
+        'password' => 'rabbit',
+        'roles' => array(
+            'monitoring',
+        ),
+    ),
+    'Bunny' => array(
+        'password' => 'bugs',
+        'roles' => array(
+            'policymaker',
+        ),
+    ),
+));
+
+/**
+ * You can edit the user permissions here
+ *
+ * $permissions = arrray(
+ *     '{USERNAME}' => array(
+ *         '{VHOST}' => array(
+ *             'ip' => '{REGEX_IP}',
+ *             'read' => '{REGEX_READ}',
+ *             'write' => '{REGEX_WRITE}',
+ *             'configure' => '{REGEX_CONFIGURE}',
+ *         ),
+ *     ),
+ * );
+ */
+$permissions = array(
+    'Anthony' => array(
+        'isAdmin' => true,
+    ),
+    'James' => array(
+        '/' => array(
+            'ip' => '.*',
+            'read' => '.*',
+            'write' => '.*',
+            'configure' => '.*',
+        ),
+    ),
+);
+
+/**
+ * Authenticator initialisation
+ *
+ * His gonna to find the user (with user provider) and to check the authentication with the authentication checker.
+ *
+ * We are 2 types of access token:
+ *   - UserPasswordToken use with the user endpoint (to check the username and the password validity)
+ *   - UserToken use with resource/topic/vhost endpoint (to check the username existence)
+ */
+$authenticator = new Authenticator(
+    $userProvider,
+    new ChainAuthenticationChecker(array(
+        new UserPasswordTokenChecker(),
+        new UserTokenChecker(),
+    ))
+);
+
+/**
+ * DefaultVoter is used to check the authorization.
+ *
+ * This class has the same implementation of default RabbitMQ authorization process.
+ *
+ * $permission is the configured user permission
+ */
+$defaultVoter = new DefaultVoter($permissions);
+
+/**
+ * This class is the initialisation of the symfony/security component
+ */
+$authenticationManager = new AuthenticationProviderManager(array($authenticator));
+$accessDecisionManager = new AccessDecisionManager(array($defaultVoter));
+
+$tokenStorage = new TokenStorage();
+
+$authorizationChecker = new AuthorizationChecker(
+    $tokenStorage,
+    $authenticationManager,
+    $accessDecisionManager
+);
+
+/**
+ * The security class is the main class
+ */
+$security = new Security($authenticationManager, $authorizationChecker);
+
+/**
+ * This is the auth controller.
+ *
+ * It take the http request and return the http response
+ */
+$authController = new AuthController($tokenStorage, $security);
+
+/** Add a logger */
+$stream = new StreamHandler(__DIR__.'/../var/log.log', Logger::DEBUG);
+$authenticator->setLogger((new Logger('rabbitmq_authenticator'))->pushHandler($stream));
+$defaultVoter->setLogger((new Logger('rabbitmq_default_voter'))->pushHandler($stream));
+$security->setLogger((new Logger('rabbitmq_security'))->pushHandler($stream));

--- a/examples/rabbitmq_auth_backend_php/src/resource.php
+++ b/examples/rabbitmq_auth_backend_php/src/resource.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once '../vendor/autoload.php';
+require_once 'bootstrap.php';
+
+/**
+ * The resource action handle the request and check the authentication + authorization of the request params
+ * It check the QUERYSTRING params before the payload.
+ */
+$response = $authController->resourceAction(
+    \Symfony\Component\HttpFoundation\Request::createFromGlobals() // Create an request object
+);
+
+$response->send(); // send the http response

--- a/examples/rabbitmq_auth_backend_php/src/topic.php
+++ b/examples/rabbitmq_auth_backend_php/src/topic.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once '../vendor/autoload.php';
+require_once 'bootstrap.php';
+
+/**
+ * The resource action handle the request and check the authentication + authorization of the request params
+ * It check the QUERYSTRING params before the payload.
+ */
+$response = $authController->topicAction(
+    \Symfony\Component\HttpFoundation\Request::createFromGlobals() // Create an request object
+);
+
+$response->send(); // send the http response

--- a/examples/rabbitmq_auth_backend_php/src/user.php
+++ b/examples/rabbitmq_auth_backend_php/src/user.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once '../vendor/autoload.php';
+require_once 'bootstrap.php';
+
+/**
+ * The resource action handle the request and check the authentication + authorization of the request params
+ * It check the QUERYSTRING params before the payload.
+ */
+$response = $authController->userAction(
+    \Symfony\Component\HttpFoundation\Request::createFromGlobals() // Create an request object
+);
+
+$response->send(); // send the http response

--- a/examples/rabbitmq_auth_backend_php/src/vhost.php
+++ b/examples/rabbitmq_auth_backend_php/src/vhost.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once '../vendor/autoload.php';
+require_once 'bootstrap.php';
+
+/**
+ * The resource action handle the request and check the authentication + authorization of the request params
+ * It check the QUERYSTRING params before the payload.
+ */
+$response = $authController->vhostAction(
+    \Symfony\Component\HttpFoundation\Request::createFromGlobals() // Create an request object
+);
+
+$response->send(); // send the http response


### PR DESCRIPTION
This example just depend on [`symftony/rabbitmq-auth-backend-http-php`](https://github.com/symftony/rabbitmq-auth-backend-http-php) and [`monolog/monolog`](https://github.com/Seldaek/monolog)

The library need php>=5.3 but in this example you need php5.4 (only for the built-in dev server)

⚠️ I see an RabbitMQ error when i start the server on `localhost`. But working well with `127.0.0.1`