### PR TITLE
Accept 201s as well as 200s

### DIFF
--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -140,6 +140,10 @@ do_http_req(PathName, Query) ->
                            {error, _} = E -> E;
                            Resp           -> Resp
                        end;
+                201 -> case parse_resp(Body) of
+                           {error, _} = E -> E;
+                           Resp           -> Resp
+                       end;
                 _   -> {error, {Code, Body}}
             end;
         {error, _} = E ->


### PR DESCRIPTION
A 201 (Created) is a valid success response.  Merging this upstream would help us avoid continuously rebasing, but more importantly allow others to use a perfectly valid 201 response too.