### PR TITLE
Cache vhost access requests using client IP address only

### DIFF
--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -61,7 +61,7 @@ user_login_authorization(Username, AuthProps) ->
 check_vhost_access(#auth_user{username = Username, tags = Tags}, VHost, #{peeraddr := PeerAddr}) ->
     bool_req(vhost_path, [{username, Username},
                           {vhost,    VHost},
-                          {ip,       PeerAddr},
+                          {ip,       inet:ntoa(PeerAddr)},
                           {tags, join_tags(Tags)}]).
 
 check_resource_access(#auth_user{username = Username, tags = Tags},

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -170,15 +170,3 @@ join_tags([])   -> "";
 join_tags(Tags) ->
   Strings = [rabbit_data_coercion:to_list(T) || T <- Tags],
   string:join(Strings, " ").
-
-%%--------------------------------------------------------------------
-
-extract_address(undefined) -> undefined;
-% for native direct connections the address is set to unknown
-extract_address(#authz_socket_info{peername = {unknown, _Port}}) -> undefined;
-extract_address(#authz_socket_info{peername = {Address, _Port}}) -> inet_parse:ntoa(Address);
-extract_address(Sock) ->
-    {ok, {Address, _Port}} = rabbit_net:peername(Sock),
-    inet_parse:ntoa(Address).
-
-%%--------------------------------------------------------------------

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -58,10 +58,10 @@ user_login_authorization(Username, AuthProps) ->
         Else                          -> Else
     end.
 
-check_vhost_access(#auth_user{username = Username, tags = Tags}, VHost, Sock) ->
+check_vhost_access(#auth_user{username = Username, tags = Tags}, VHost, #{peeraddr := PeerAddr}) ->
     bool_req(vhost_path, [{username, Username},
                           {vhost,    VHost},
-                          {ip,       extract_address(Sock)},
+                          {ip,       PeerAddr},
                           {tags, join_tags(Tags)}]).
 
 check_resource_access(#auth_user{username = Username, tags = Tags},

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -61,8 +61,8 @@ user_login_authorization(Username, AuthProps) ->
 check_vhost_access(#auth_user{username = Username, tags = Tags}, VHost, #{peeraddr := PeerAddr}) ->
     bool_req(vhost_path, [{username, Username},
                           {vhost,    VHost},
-                          {ip,       inet:ntoa(PeerAddr)},
-                          {tags, join_tags(Tags)}]).
+                          {ip,       parse_peeraddr(PeerAddr)},
+                          {tags,     join_tags(Tags)}]).
 
 check_resource_access(#auth_user{username = Username, tags = Tags},
                       #resource{virtual_host = VHost, kind = Type, name = Name},
@@ -170,3 +170,11 @@ join_tags([])   -> "";
 join_tags(Tags) ->
   Strings = [rabbit_data_coercion:to_list(T) || T <- Tags],
   string:join(Strings, " ").
+
+parse_peeraddr(PeerAddr) ->
+    handle_inet_ntoa_peeraddr(inet:ntoa(PeerAddr), PeerAddr).
+
+handle_inet_ntoa_peeraddr({error, einval}, PeerAddr) ->
+    rabbit_data_coercion:to_list(PeerAddr);
+handle_inet_ntoa_peeraddr(PeerAddrStr, _PeerAddr0) ->
+    PeerAddrStr.


### PR DESCRIPTION
Fixes rabbitmq/rabbitmq-auth-backend-cache#22