### PR TITLE
Updated Readme.md to include HTTP Method in conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Below is a minimal configuration file example.
 In `rabbitmq.conf`:
 
     auth_backends.1 = http
+    auth_http.http_method   = post
     auth_http.user_path     = http://some-server/auth/user
     auth_http.vhost_path    = http://some-server/auth/vhost
     auth_http.resource_path = http://some-server/auth/resource


### PR DESCRIPTION
The rabbitmq.conf section in new format is missing the inclusion of HTTP METHOD due to which it default to a Get call and does not work for controller methods defined for HttpPost . This what most of the examples in the repo outline as well for the AuthBackend.