### PR TITLE
Do not error on deny from http server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endef
 
 LOCAL_DEPS = inets
 DEPS = rabbit_common rabbit amqp_client
-TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers
+TEST_DEPS = rabbitmq_ct_helpers rabbitmq_ct_client_helpers cowboy
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/src/rabbit_auth_backend_http.erl
+++ b/src/rabbit_auth_backend_http.erl
@@ -43,7 +43,7 @@ description() ->
 user_login_authentication(Username, AuthProps) ->
     case http_req(p(user_path), q([{username, Username}|AuthProps])) of
         {error, _} = E  -> E;
-        deny            -> {refused, "Denied by HTTP plugin", []};
+        "deny"          -> {refused, "Denied by HTTP plugin", []};
         "allow" ++ Rest -> Tags = [rabbit_data_coercion:to_atom(T) ||
                                       T <- string:tokens(Rest, " ")],
                            {ok, #auth_user{username = Username,

--- a/test/auth_SUITE.erl
+++ b/test/auth_SUITE.erl
@@ -1,0 +1,71 @@
+%% The contents of this file are subject to the Mozilla Public License
+%% Version 1.1 (the "License"); you may not use this file except in
+%% compliance with the License. You may obtain a copy of the License at
+%% http://www.mozilla.org/MPL/
+%%
+%% Software distributed under the License is distributed on an "AS IS"
+%% basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+%% License for the specific language governing rights and limitations
+%% under the License.
+%%
+%% The Original Code is RabbitMQ.
+%%
+%% The Initial Developer of the Original Code is GoPivotal, Inc.
+%% Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
+
+-module(auth_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
+
+-compile(export_all).
+
+-define(AUTH_PORT, 8000).
+-define(USER_PATH, "/auth/user").
+-define(BACKEND_CONFIG,
+	[{http_method, get},
+     {user_path, "http://localhost:" ++ integer_to_list(?AUTH_PORT) ++ ?USER_PATH},
+	 {vhost_path, "http://localhost:" ++ integer_to_list(?AUTH_PORT) ++ "/auth/vhost"},
+     {resource_path, "http://localhost:" ++ integer_to_list(?AUTH_PORT) ++ "/auth/resource"},
+	 {topic_path, "http://localhost:" ++ integer_to_list(?AUTH_PORT) ++ "/auth/topic"}]).
+-define(ALLOWED_USER, #{username => <<"Ala">>, 
+                        password => <<"Kocur">>,   
+                        tags => [policymaker, monitoring]}).
+-define(DENIED_USER, #{username => <<"Alice">>, password => <<"Cat">>}).
+
+all() -> [grants_access_to_user, denies_access_to_user].
+
+init_per_suite(Config) ->
+    configure_http_auth_backend(),
+    #{username := Username, password := Password, tags := Tags} = ?ALLOWED_USER,
+    start_http_auth_server(?AUTH_PORT, ?USER_PATH, #{Username => {Password, Tags}}),
+    [{allowed_user, ?ALLOWED_USER}, {denied_user, ?DENIED_USER} | Config].
+
+end_per_suite(_Config) -> 
+    stop_http_auth_server().
+
+grants_access_to_user(Config) ->
+    #{username := U, password := P, tags := T} = ?config(allowed_user, Config),
+    ?assertMatch({ok, #auth_user{username = U, tags = T}},
+		         rabbit_auth_backend_http:user_login_authentication(U, [{password, P}])).
+
+denies_access_to_user(Config) ->
+    #{username := U, password := P} = ?config(denied_user, Config),
+    ?assertMatch({refused,"Denied by HTTP plugin",[]},
+                  rabbit_auth_backend_http:user_login_authentication(U, [{password, P}])).
+
+%%% HELPERS
+
+configure_http_auth_backend() ->
+    {ok, _} = application:ensure_all_started(inets),
+    [application:set_env(rabbitmq_auth_backend_http, K, V) || {K, V} <- ?BACKEND_CONFIG].
+
+start_http_auth_server(Port, Path, Users) ->
+    application:ensure_all_started(cowboy),
+    Dispatch = cowboy_router:compile([{'_', [{Path, auth_http_mock, Users}]}]),
+    {ok, _} = cowboy:start_clear(
+        mock_http_auth_listener, [{port, Port}], #{env => #{dispatch => Dispatch}}).
+
+stop_http_auth_server() ->
+    cowboy:stop_listener(mock_http_auth_listener).

--- a/test/auth_http_mock.erl
+++ b/test/auth_http_mock.erl
@@ -1,0 +1,26 @@
+-module(auth_http_mock).
+
+-export([init/2]).
+
+%%% CALLBACKS
+
+init(Req = #{method := <<"GET">>}, Users) ->
+    QsVals = cowboy_req:parse_qs(Req),
+    Reply = authenticate(proplists:get_value(<<"username">>, QsVals),
+                         proplists:get_value(<<"password">>, QsVals),
+                         Users),
+    Req2 = cowboy_req:reply(200, #{<<"content-type">> => <<"text/plain">>}, Reply, Req),
+    {ok, Req2, Users}.
+
+%%% HELPERS
+
+authenticate(Username, Password, Users) ->
+   case maps:get(Username, Users, undefined) of
+       {MatchingPassword, Tags} when Password =:= MatchingPassword ->
+           StringTags = lists:map(fun(T) -> io_lib:format("~s", [T]) end, Tags),
+           <<"allow ", (list_to_binary(string:join(StringTags, " ")))/binary>>;
+        {_OtherPassword, _} ->
+            <<"deny">>;
+        undefined ->
+            <<"deny">>
+   end.


### PR DESCRIPTION
So far, the "deny" response from an HTTP authentication server was parsed
as a string while an atom was expected. As a result, if the server denied
a user it simply happened to work as the plugin would return an error
because of the type mismatch and the user would not be accepted anyway.